### PR TITLE
Fix usage of deprecated `Player[] getOnlinePlayers()`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bukkitVersion>1.7.9-R0.1-SNAPSHOT</bukkitVersion>
+        <bukkitVersion>1.9-R0.1-SNAPSHOT</bukkitVersion>
         <mainClass>net.milkbowl.localshops.LocalShops</mainClass>
     </properties>
 
@@ -35,8 +35,8 @@
 
     <repositories>
 		<repository>
-			<id>bukkit-repo</id>
-			<url>http://repo.bukkit.org/content/groups/public/</url>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/public</url>
 		</repository>
         <repository>
             <id>Vault-repo</id>

--- a/src/net/milkbowl/localshops/commands/Command.java
+++ b/src/net/milkbowl/localshops/commands/Command.java
@@ -315,8 +315,7 @@ public abstract class Command {
 	}
 
 	protected boolean notifyPlayers(Shop shop, String...messages) {
-		Player[] players = plugin.getServer().getOnlinePlayers();
-		for(Player p : players) {
+		for(Player p : plugin.getServer().getOnlinePlayers()) {
 			if(shop.containsPoint(p.getLocation())) {
 				for (String message : messages) {
 					p.sendMessage(message);

--- a/src/net/milkbowl/localshops/commands/CommandShopDestroy.java
+++ b/src/net/milkbowl/localshops/commands/CommandShopDestroy.java
@@ -112,8 +112,7 @@ public class CommandShopDestroy extends Command {
                 return false;
             }
 
-            Player[] players = plugin.getServer().getOnlinePlayers();
-            for(Player p : players) {
+            for(Player p : plugin.getServer().getOnlinePlayers()) {
                 if(shop.containsPoint(p.getLocation())) {
                     p.sendMessage(plugin.getResourceManager().getChatPrefix() + " " + ChatColor.WHITE + shop.getName() + ChatColor.DARK_AQUA + " has been destroyed");
                 }


### PR DESCRIPTION
Spigot 1.9 removes deprecated support for old Bukkit 1.7 methods, i.e. in this case `Player[] getOnlinePlayers`. It has been changed to use `Collection<? extends Player> getOnlinePlayers()`.
